### PR TITLE
fix strictInputAccessModifiers tsconfig angularCompilerOptions

### DIFF
--- a/packages/examples/src/app/drilldown/box.component.ts
+++ b/packages/examples/src/app/drilldown/box.component.ts
@@ -18,7 +18,7 @@ import { ItemTypes } from './itemTypes';
       background-color: white;
       width: 8rem;;
     }
-    div, p { display: inline-block;, padding: 3px; margin: 0; }
+    div, p { display: inline-block; padding: 3px; margin: 0; }
   `]
 })
 export class BoxComponent implements OnDestroy {

--- a/packages/examples/src/app/nested/targets/box.component.ts
+++ b/packages/examples/src/app/nested/targets/box.component.ts
@@ -17,7 +17,7 @@ import { ItemTypes } from './item-types';
       width: 8rem;
       margin-bottom: 1rem;
     }
-    p { display: inline-block;, padding: 3px; margin: 0; }
+    p { display: inline-block; padding: 3px; margin: 0; }
   `]
 })
 export class BoxComponent implements OnDestroy {

--- a/packages/sortable/src/directives/sortable.directive.ts
+++ b/packages/sortable/src/directives/sortable.directive.ts
@@ -21,7 +21,7 @@ import { isEmpty } from '../isEmpty';
 export class DndSortable<Data> implements OnInit, OnChanges, OnDestroy, AfterViewInit {
   @Input() listId: any = Math.random().toString();
   @Input() horizontal = false;
-  @Input() protected spec!: SortableSpec<Data>;
+  @Input() spec!: SortableSpec<Data>;
   @Input() children?: Iterable<Data>;
   /**
    * Possible values:


### PR DESCRIPTION
Build fails if using strict angular compiler options in tsconfig - because `spec` has modifier `protected`.
(and `;, padding: ...` fails as well if css / scss checks are enabled as well)

```
"angularCompilerOptions": {
    ...
    "strictInputAccessModifiers": true,
    ...
  },
```