### PR TITLE
Fix AddSubscription type

### DIFF
--- a/packages/core/src/connector.service.ts
+++ b/packages/core/src/connector.service.ts
@@ -33,7 +33,7 @@ import { createSourceFactory } from "./internal/createSourceFactory";
  */
 export interface AddSubscription extends SubscriptionLike {
   /** Same as RxJS `Subscription#add` */
-  add(teardownLogic: TeardownLogic): AddSubscription;
+  add(teardownLogic: TeardownLogic): any;
 }
 
 /**


### PR DESCRIPTION
Newer versions of rxjs return `void` for `Subscription.add`, this allows type support for those versions as well.