### PR TITLE
Misc Fixes

### DIFF
--- a/packages/multi-backend/src/preview.component.ts
+++ b/packages/multi-backend/src/preview.component.ts
@@ -92,7 +92,7 @@ export class DndPreviewComponent implements BackendWatcher, OnInit, OnDestroy {
     if (this.manager == null) {
       this.warn('no drag and drop manager defined, are you sure you imported DndModule?');
     } else {
-      (this.manager.getBackend() as MultiBackendExt).previews!.register(this);
+      (this.manager.getBackend() as MultiBackendExt).previews?.register(this);
     }
   }
 
@@ -110,7 +110,7 @@ export class DndPreviewComponent implements BackendWatcher, OnInit, OnDestroy {
   /** @ignore */
   ngOnDestroy() {
     this.layer.unsubscribe();
-    (this.manager.getBackend() as MultiBackendExt).previews!.unregister(this);
+    (this.manager.getBackend() as MultiBackendExt).previews?.unregister(this);
   }
 
   /** @ignore */

--- a/packages/sortable/src/hoverTriggers.ts
+++ b/packages/sortable/src/hoverTriggers.ts
@@ -48,6 +48,10 @@ export function suggestHalfway<Data>(
       suggestedIndex = topHalf ? ctx.index : ctx.index + 1;
     } else {
       suggestedIndex = topHalf ? ctx.index - 1 : ctx.index;
+      if (suggestedIndex < 0) {
+        // Fix rare issue when trying to drag too high
+        suggestedIndex = 0;
+      }
     }
   } else {
     // first hover on a different list;


### PR DESCRIPTION
First commit fixes a (rare) problem in sortable lists. Dragging/hovering an item near the top of a list would sometimes (depending on speed of the mouse movement) result in `suggestedIndex` of -1, breaking the drag.

Second commit fixes and issue when using DndPreview but *not* using the MultiBackend, the `previews` attribute wouldn't actually exist.